### PR TITLE
32 fix: 신규 Participant 투표 생성 시 JPA 예외 발생

### DIFF
--- a/adapter/rdb/src/main/kotlin/com/nomoney/meeting/entity/ParticipantJpaEntity.kt
+++ b/adapter/rdb/src/main/kotlin/com/nomoney/meeting/entity/ParticipantJpaEntity.kt
@@ -19,7 +19,7 @@ class ParticipantJpaEntity : BaseJpaEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "participant_id", nullable = false)
-    var participantId: Long? = null
+    var participantId: Long = 0L
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meet_id", nullable = false)
@@ -33,7 +33,7 @@ class ParticipantJpaEntity : BaseJpaEntity() {
 
     companion object {
         fun of(
-            participantId: Long?,
+            participantId: Long = 0L,
             meeting: MeetingJpaEntity,
             name: String,
             voteDates: MutableSet<ParticipantVoteDateJpaEntity> = mutableSetOf(),

--- a/adapter/rdb/src/main/kotlin/com/nomoney/meeting/entity/ParticipantVoteDateJpaEntity.kt
+++ b/adapter/rdb/src/main/kotlin/com/nomoney/meeting/entity/ParticipantVoteDateJpaEntity.kt
@@ -33,7 +33,7 @@ class ParticipantVoteDateJpaEntity : BaseJpaEntity() {
         fun of(participant: ParticipantJpaEntity, voteDate: LocalDate): ParticipantVoteDateJpaEntity {
             return ParticipantVoteDateJpaEntity().apply {
                 this.id = ParticipantVoteDateId(
-                    participantId = null,
+                    participantId = 0L,
                     voteDate = voteDate,
                 )
                 this.participant = participant
@@ -45,7 +45,7 @@ class ParticipantVoteDateJpaEntity : BaseJpaEntity() {
 @Embeddable
 data class ParticipantVoteDateId(
     @Column(name = "participant_id")
-    var participantId: Long? = null,
+    var participantId: Long = 0L,
 
     @Column(name = "vote_date")
     var voteDate: LocalDate = LocalDate.now(),


### PR DESCRIPTION
ISSUE #32 에 자세히 작성
 
> 우선 기존 코드를 최대한 유지하는 방향으로 수정을 진행했습니다.

## 문제 요약

`/api/v1/meeting/vote` API 호출 시,
비즈니스 로직은 정상 수행되나 엔티티 영속화 단계에서 Hibernate 예외가 발생하며
트랜잭션이 롤백되는 문제가 발생함.

원인은 다음 두 가지 구조적 문제의 결합이었음.

1. `ParticipantVoteDate`가 `(participant_id, vote_date)` 복합 PK를 사용하고 있어,
   아직 영속화되지 않은 신규 `Participant`의 ID가 필요한 시점에
   PK 생성을 시도하며 예외가 발생함.

2. `Meeting` 저장 시 기존 엔티티를 재사용하지 않고
   전체 엔티티 그래프를 새로 생성하여 저장하면서,
   기존 `Participant`의 `voteDates`까지 신규 엔티티로 인식되어
   이미 존재하는 `(participant_id, vote_date)`가 중복 insert됨.

## 해결 내용

- `ParticipantVoteDate`의 복합 키를  
  `@IdClass` → `@EmbeddedId + @MapsId` 구조로 변경하여
  Participant 영속화 이후 ID가 자동으로 매핑되도록 수정
- `Meeting` 저장 시 기존 `MeetingJpaEntity`를 조회한 뒤
  update-in-place + diff 기반 병합 방식으로 변경하여
  기존 `participant_vote_dates`의 중복 insert를 방지

---

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)  

### 🔗 Related Issue

Closes #32

