### PR TITLE
86 fix: 히카리 커넥션 풀 설정 및 Swagger/스캐너 예외 처리 개선

### DIFF
--- a/adapter/rdb/src/main/resources/application-rdb.yml
+++ b/adapter/rdb/src/main/resources/application-rdb.yml
@@ -8,8 +8,10 @@ spring:
       maximum-pool-size: 10
       minimum-idle: 1
       connection-timeout: 10000
-      idle-timeout: 30000
-      max-lifetime: 30000
+      validation-timeout: 5000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      keepalive-time: 300000
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/app/api/build.gradle.kts
+++ b/app/api/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
     implementation("io.awspring.cloud:spring-cloud-starter-aws-parameter-store-config")
 
     implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.28.0")
+
+    testImplementation("org.springframework:spring-test")
 }
 
 tasks {

--- a/app/api/src/main/kotlin/com/nomoney/api/auth/TokenAuthenticationFilter.kt
+++ b/app/api/src/main/kotlin/com/nomoney/api/auth/TokenAuthenticationFilter.kt
@@ -6,22 +6,35 @@ import com.nomoney.exception.NoMoneyException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class TokenAuthenticationFilter(
     private val authService: AuthService,
 ) : OncePerRequestFilter() {
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        val requestPath = request.requestURI.removePrefix(request.contextPath)
+        return EXCLUDED_PATH_PATTERNS.any { pattern -> pathMatcher.match(pattern, requestPath) }
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
+        val tokenCredential = resolveTokenCredential(request)
+        if (tokenCredential == null) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
         try {
-            val accessToken = resolveToken(request) ?: return
+            val accessToken = tokenCredential.value
 
             val user = authService.validateToken(accessToken)
 
@@ -36,18 +49,33 @@ class TokenAuthenticationFilter(
                 emptyList(), // authorities.map { SimpleGrantedAuthority(it.name) },
             )
         } catch (e: NoMoneyException) {
+            authLogger.warn(
+                "Token validation failed. path={}, credentialSource={}, exceptionType={}",
+                request.requestURI,
+                tokenCredential.source,
+                e::class.simpleName,
+            )
             request.setAttribute(TOKEN_VALIDATION_ERROR_ATTR, e)
-        } finally {
-            filterChain.doFilter(request, response)
+        } catch (e: RuntimeException) {
+            authLogger.error(
+                "Token validation infrastructure error. path={}, credentialSource={}, exceptionType={}",
+                request.requestURI,
+                tokenCredential.source,
+                e::class.simpleName,
+                e,
+            )
+            throw e
         }
+
+        filterChain.doFilter(request, response)
     }
 
-    private fun resolveToken(request: HttpServletRequest): String? {
+    private fun resolveTokenCredential(request: HttpServletRequest): TokenCredential? {
         val authHeader = request.getHeader(HEADER_AUTHORIZATION)
         if (authHeader != null) {
             val headerData = authHeader.split(' ')
             if (headerData.size == 2 && headerData[0].lowercase() == AUTHORIZATION_METHOD && headerData[1].isNotBlank()) {
-                return headerData[1]
+                return TokenCredential(headerData[1], CredentialSource.HEADER)
             }
         }
 
@@ -55,9 +83,30 @@ class TokenAuthenticationFilter(
             ?.firstOrNull { it.name == COOKIE_ACCESS_TOKEN }
             ?.value
             ?.takeIf { it.isNotBlank() }
+            ?.let { TokenCredential(it, CredentialSource.COOKIE) }
+    }
+
+    private data class TokenCredential(
+        val value: String,
+        val source: CredentialSource,
+    )
+
+    private enum class CredentialSource {
+        HEADER,
+        COOKIE,
     }
 
     companion object {
+        private val authLogger = LoggerFactory.getLogger(TokenAuthenticationFilter::class.java)
+        private val pathMatcher = AntPathMatcher()
+        private val EXCLUDED_PATH_PATTERNS = listOf(
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/actuator/health",
+            "/actuator/info",
+            "/actuator/prometheus",
+            "/favicon.ico",
+        )
         private const val HEADER_AUTHORIZATION = "Authorization"
         private const val AUTHORIZATION_METHOD = "bearer"
         private const val COOKIE_ACCESS_TOKEN = "access_token"

--- a/app/api/src/main/kotlin/com/nomoney/api/exception/GlobalExceptionHandler.kt
+++ b/app/api/src/main/kotlin/com/nomoney/api/exception/GlobalExceptionHandler.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.NoHandlerFoundException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -115,6 +116,16 @@ class GlobalExceptionHandler {
             code = "E404",
             message = "요청한 리소스를 찾을 수 없습니다.",
             messageForDev = "핸들러를 찾을 수 없습니다: ${ex.httpMethod} ${ex.requestURL}",
+        )
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse)
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFoundException(ex: NoResourceFoundException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(
+            code = "E404",
+            message = "요청한 리소스를 찾을 수 없습니다.",
+            messageForDev = "정적 리소스를 찾을 수 없습니다: ${ex.httpMethod} ${ex.resourcePath}",
         )
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse)
     }

--- a/app/api/src/test/kotlin/com/nomoney/api/auth/TokenAuthenticationFilterTest.kt
+++ b/app/api/src/test/kotlin/com/nomoney/api/auth/TokenAuthenticationFilterTest.kt
@@ -103,4 +103,4 @@ class TokenAuthenticationFilterTest : DescribeSpec({
             }
         }
     }
-})
+},)

--- a/app/api/src/test/kotlin/com/nomoney/api/auth/TokenAuthenticationFilterTest.kt
+++ b/app/api/src/test/kotlin/com/nomoney/api/auth/TokenAuthenticationFilterTest.kt
@@ -1,0 +1,106 @@
+package com.nomoney.api.auth
+
+import com.nomoney.auth.domain.User
+import com.nomoney.auth.domain.UserId
+import com.nomoney.auth.service.AuthService
+import com.nomoney.exception.UnauthorizedException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+
+class TokenAuthenticationFilterTest : DescribeSpec({
+    val authService = mockk<AuthService>()
+    val filter = TokenAuthenticationFilter(authService)
+
+    beforeTest {
+        clearMocks(authService)
+        SecurityContextHolder.clearContext()
+    }
+
+    afterTest {
+        SecurityContextHolder.clearContext()
+    }
+
+    describe("TokenAuthenticationFilter") {
+        describe("문서/진단 경로 우회") {
+            it("Swagger api-docs 요청은 access_token 쿠키가 있어도 토큰 검증을 하지 않는다") {
+                val request = mockk<HttpServletRequest>(relaxed = true)
+                val response = MockHttpServletResponse()
+                val filterChain = mockk<MockFilterChain>(relaxed = true)
+
+                every { request.requestURI } returns "/v3/api-docs"
+                every { request.contextPath } returns ""
+                every { request.cookies } returns arrayOf(Cookie("access_token", "cookie-token"))
+
+                filter.doFilter(request, response, filterChain)
+
+                verify(exactly = 0) { authService.validateToken(any()) }
+                verify(exactly = 1) { filterChain.doFilter(request, response) }
+            }
+
+            it("Prometheus 요청은 Authorization 헤더가 있어도 토큰 검증을 하지 않는다") {
+                val request = MockHttpServletRequest("GET", "/actuator/prometheus").apply {
+                    addHeader("Authorization", "Bearer header-token")
+                }
+                val response = MockHttpServletResponse()
+
+                filter.doFilter(request, response, MockFilterChain())
+
+                verify(exactly = 0) { authService.validateToken(any()) }
+            }
+        }
+
+        describe("비즈니스 API 인증") {
+            it("비즈니스 API 요청은 기존처럼 토큰 검증을 수행한다") {
+                val request = MockHttpServletRequest("GET", "/api/v1/users/me").apply {
+                    addHeader("Authorization", "Bearer header-token")
+                }
+                val response = MockHttpServletResponse()
+                every { authService.validateToken("header-token") } returns User(UserId(1L))
+
+                filter.doFilter(request, response, MockFilterChain())
+
+                verify(exactly = 1) { authService.validateToken("header-token") }
+                getSecurityUserId() shouldBe UserId(1L)
+            }
+
+            it("유효하지 않은 토큰은 요청 속성에 저장하고 다음 체인으로 전달한다") {
+                val request = MockHttpServletRequest("GET", "/api/v1/users/me").apply {
+                    addHeader("Authorization", "Bearer invalid-token")
+                }
+                val response = MockHttpServletResponse()
+                val exception = UnauthorizedException("invalid")
+                every { authService.validateToken("invalid-token") } throws exception
+
+                filter.doFilter(request, response, MockFilterChain())
+
+                verify(exactly = 1) { authService.validateToken("invalid-token") }
+                request.getAttribute(TOKEN_VALIDATION_ERROR_ATTR) shouldBe exception
+            }
+
+            it("인프라 예외는 그대로 전파한다") {
+                val request = MockHttpServletRequest("GET", "/api/v1/users/me").apply {
+                    addHeader("Authorization", "Bearer broken-token")
+                }
+                val response = MockHttpServletResponse()
+                every { authService.validateToken("broken-token") } throws IllegalStateException("db down")
+
+                shouldThrow<IllegalStateException> {
+                    filter.doFilter(request, response, MockFilterChain())
+                }
+
+                verify(exactly = 1) { authService.validateToken("broken-token") }
+            }
+        }
+    }
+})

--- a/app/api/src/test/kotlin/com/nomoney/api/exception/GlobalExceptionHandlerTest.kt
+++ b/app/api/src/test/kotlin/com/nomoney/api/exception/GlobalExceptionHandlerTest.kt
@@ -26,4 +26,4 @@ class GlobalExceptionHandlerTest : DescribeSpec({
             )
         }
     }
-})
+},)

--- a/app/api/src/test/kotlin/com/nomoney/api/exception/GlobalExceptionHandlerTest.kt
+++ b/app/api/src/test/kotlin/com/nomoney/api/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,29 @@
+package com.nomoney.api.exception
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.web.servlet.resource.NoResourceFoundException
+
+class GlobalExceptionHandlerTest : DescribeSpec({
+    val handler = GlobalExceptionHandler()
+
+    describe("GlobalExceptionHandler") {
+        it("정적 리소스 미존재 예외는 404로 응답한다") {
+            val exception = NoResourceFoundException(
+                HttpMethod.GET,
+                "/api/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php",
+            )
+
+            val response = handler.handleNoResourceFoundException(exception)
+
+            response.statusCode shouldBe HttpStatus.NOT_FOUND
+            response.body shouldBe ErrorResponse(
+                code = "E404",
+                message = "요청한 리소스를 찾을 수 없습니다.",
+                messageForDev = "정적 리소스를 찾을 수 없습니다: GET /api/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php",
+            )
+        }
+    }
+})

--- a/support/logging/src/main/kotlin/com/nomoney/support/logging/ApiLoggingFilter.kt
+++ b/support/logging/src/main/kotlin/com/nomoney/support/logging/ApiLoggingFilter.kt
@@ -7,7 +7,9 @@ import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
 import org.slf4j.MDC
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.util.ContentCachingRequestWrapper
 import org.springframework.web.util.ContentCachingResponseWrapper
@@ -22,7 +24,7 @@ import kotlin.to
 class ApiLoggingFilter(
     private val objectMapper: ObjectMapper,
 ) : Filter {
-    private val logger = logger()
+    private val logger = LoggerFactory.getLogger(ApiLoggingFilter::class.java)
 
     override fun doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse, chain: FilterChain) {
         registerRequestId()
@@ -32,10 +34,18 @@ class ApiLoggingFilter(
         try {
             chain.doFilter(request, response)
         } finally {
-            logger.info(generateLog(request, response))
+            if (!shouldSkipLogging(request, response)) {
+                logger.info(generateLog(request, response))
+            }
             response.copyBodyToResponse()
             MDC.clear()
         }
+    }
+
+    internal fun shouldSkipLogging(request: HttpServletRequest, response: HttpServletResponse): Boolean {
+        val requestPath = request.requestURI.removePrefix(request.contextPath)
+        return response.status == HttpStatus.NOT_FOUND.value() &&
+            SUPPORTED_API_PREFIXES.none { prefix -> requestPath == prefix.removeSuffix("/") || requestPath.startsWith(prefix) }
     }
 
     private fun generateLog(request: ContentCachingRequestWrapper, response: ContentCachingResponseWrapper): String {
@@ -56,5 +66,9 @@ class ApiLoggingFilter(
         )
 
         return objectMapper.writeValueAsString(data)
+    }
+
+    companion object {
+        private val SUPPORTED_API_PREFIXES = listOf("/api/v1/")
     }
 }

--- a/support/logging/src/main/kotlin/com/nomoney/support/logging/ApiLoggingFilter.kt
+++ b/support/logging/src/main/kotlin/com/nomoney/support/logging/ApiLoggingFilter.kt
@@ -7,9 +7,9 @@ import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.http.HttpStatus
-import org.slf4j.MDC
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.util.ContentCachingRequestWrapper
 import org.springframework.web.util.ContentCachingResponseWrapper


### PR DESCRIPTION
### 작업 내용
- HikariCP 커넥션 풀 설정을 조정해 저트래픽 환경에서 커넥션 재생성 실패가 쉽게 드러나던 문제를 완화했습니다.
- Swagger, Prometheus, Actuator 등 문서/진단 경로는 `TokenAuthenticationFilter` 를 우회하도록 변경했습니다.
- 인증 토큰 검증 실패 로그에 요청 경로, credential source, 예외 타입을 남기도록 보강했습니다.
- `NoResourceFoundException` 을 404로 처리해 스캐너성 요청이 500으로 집계되지 않도록 수정했습니다.
- 실제 서비스 API prefix(`/api/v1/`) 외의 `/api/*` 404 요청은 트랜잭션 로그에서 제외해 모니터링 노이즈를 줄였습니다.
- 관련 테스트(`TokenAuthenticationFilterTest`, `GlobalExceptionHandlerTest`)를 추가했습니다.
 
### 참고 사항

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)

### 🔗 Related Issue

Closes #86

